### PR TITLE
lua 5.2 compat

### DIFF
--- a/src/ldes56.c
+++ b/src/ldes56.c
@@ -137,7 +137,7 @@ static void set_info (lua_State *L) {
 	lua_settable (L, -3);
 }
 
-static const struct luaL_reg des56lib[] = {
+static const struct luaL_Reg des56lib[] = {
   {"crypt", des56_crypt},
   {"decrypt", des56_decrypt},
   {NULL, NULL},

--- a/src/md5lib.c
+++ b/src/md5lib.c
@@ -48,7 +48,7 @@ static int ex_or (lua_State *L) {
   luaL_Buffer b;
   luaL_argcheck( L, l1 == l2, 2, "lengths must be equal" );
   luaL_buffinit(L, &b);
-  while (l1--) luaL_putchar(&b, (*s1++)^(*s2++));
+  while (l1--) luaL_addchar(&b, (*s1++)^(*s2++));
   luaL_pushresult(&b);
   return 1;
 }
@@ -186,7 +186,7 @@ static void set_info (lua_State *L) {
 }
 
 
-static struct luaL_reg md5lib[] = {
+static struct luaL_Reg md5lib[] = {
   {"sum", lmd5},
   {"exor", ex_or},
   {"crypt", crypt},

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -55,7 +55,7 @@ local tolerance = 1.12
 local function contchars (s)
   local a = {}
   for i=0,255 do a[string.char(i)] = 0 end
-  for c in string.gfind(s, '.') do
+  for c in string.gmatch(s, '.') do
     a[c] = a[c] + 1
   end
   local av = string.len(s)/256


### PR DESCRIPTION
This provides basic Lua 5.2 compatibility, possibly at the expense of Lua 5.0 compatibility.  How important is it to maintain 5.0 compat?  If anyone still needs 5.0, they can just add, for example, -DluaL_Reg=luaL_reg to their makefile.
